### PR TITLE
Add terraform/gcp/persistent + per-cloud env file split

### DIFF
--- a/.env.azure.example
+++ b/.env.azure.example
@@ -1,0 +1,17 @@
+# Unity CI Enabler — Azure environment
+# Copy this file to .env.azure and fill in values.
+# Values marked [auto] are filled by scripts/sync-env.sh after terraform apply
+# in terraform/azure/persistent.
+
+# --- Manual ---
+GITHUB_TOKEN=                       # GitHub PAT (repo scope) — legacy webhook registration flow only
+                                    # (Discord-triggered design needs no cloud↔GitHub link)
+
+# --- Auto-filled from terraform azure/persistent outputs ---
+RESOURCE_GROUP_NAME=
+KEY_VAULT_NAME=
+FUNCTION_APP_URL=
+FUNCTION_APP_NAME=
+BATCH_ACCOUNT_NAME=
+IMAGE_GALLERY_NAME=
+IMAGE_DEFINITION_NAME=

--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,9 @@
-# Unity CI Enabler — Environment Variables
+# Unity CI Enabler — Common environment (cloud-agnostic)
 # Copy this file to .env and fill in values.
-# Values marked [auto] are filled by scripts/sync-env.sh after terraform apply.
+# Cloud-specific values live in .env.azure / .env.gcp (see their .example files).
+# NOTE: scripts/sync-env.sh still reads/writes Azure values in .env for now —
+#       migration to the split files is tracked separately (Issue E).
 
-# --- Manual (one-time setup) ---
-ADMIN_PASSWORD=
-REPO_URL=
+REPO_URL=                           # build target repo (public — cloned tokenless)
 PLATFORM=                           # WebGL | Android | iOS | StandaloneLinux64 | StandaloneWindows64
-GITHUB_TOKEN=                       # GitHub PAT (repo scope) — used by gh CLI on VM
-
-# --- Auto-filled from terraform persistent outputs ---
-RESOURCE_GROUP_NAME=
-KEY_VAULT_NAME=
-FUNCTION_APP_URL=
-BATCH_ACCOUNT_NAME=
-IMAGE_GALLERY_NAME=
-IMAGE_DEFINITION_NAME=
-FUNCTION_APP_NAME=
+ADMIN_PASSWORD=                     # bootstrap VM desktop login password

--- a/.env.gcp.example
+++ b/.env.gcp.example
@@ -1,0 +1,13 @@
+# Unity CI Enabler — GCP environment
+# Copy this file to .env.gcp and fill in values.
+# Feeds terraform/gcp/persistent/terraform.tfvars and (later) downloader-gcp.
+
+# --- Manual (one-time setup) ---
+ORG_ID=                             # gcloud organizations list
+BILLING_ACCOUNT=                    # gcloud billing accounts list
+PROJECT_ID=                         # globally-unique project id to create
+REGION=northamerica-northeast2      # Toronto (GCP's canada-central equivalent)
+
+# --- Auto-filled from terraform gcp/persistent outputs ---
+ARTIFACT_BUCKET_NAME=
+SECRET_STORE_NAME=                  # Secret Manager secret id for the Unity license

--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,9 @@ package-lock.json
 npm-debug.log*
 logs/
 
-# Environment variables
-.env
-.env.local
-.env.*.local
+# Environment variables — ignore all real env files, keep the examples
+.env*
+!.env*.example
 
 # OS
 .DS_Store

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -1,65 +1,97 @@
 #!/usr/bin/env bash
-# sync-env.sh — Reads terraform persistent outputs and writes them into .env
-# Usage: ./scripts/sync-env.sh
+# sync-env.sh — Reads terraform persistent outputs and writes them into the
+# cloud-specific env file (.env.azure / .env.gcp), then regenerates the
+# ephemeral terraform.tfvars for that cloud.
+#
+# Usage: ./scripts/sync-env.sh [azure|gcp]   (default: azure)
+#
+# Env file layout:
+#   .env        — common, cloud-agnostic (REPO_URL, PLATFORM, GITHUB_TOKEN, ADMIN_PASSWORD)
+#   .env.azure  — Azure resource names   (auto-filled here)
+#   .env.gcp    — GCP project/resources  (manual IDs + auto-filled outputs)
 
 set -euo pipefail
 
+CLOUD="${1:-azure}"
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ENV_FILE="$REPO_ROOT/.env"
-TF_DIR="$REPO_ROOT/terraform/azure/persistent"
+CLOUD_ENV_FILE="$REPO_ROOT/.env.$CLOUD"
+TF_DIR="$REPO_ROOT/terraform/$CLOUD/persistent"
 
-# Create .env from .env.example if it doesn't exist
-if [ ! -f "$ENV_FILE" ]; then
-  cp "$REPO_ROOT/.env.example" "$ENV_FILE"
-  echo "Created .env from .env.example"
-fi
+# Create env files from examples if they don't exist
+for f in "$ENV_FILE" "$CLOUD_ENV_FILE"; do
+  if [ ! -f "$f" ]; then
+    cp "$f.example" "$f"
+    echo "Created $(basename "$f") from example"
+  fi
+done
+
+# --- Helpers ---
+
+# update_env <file> <key> <value>
+update_env() {
+  local file="$1" key="$2" value="$3"
+  if grep -q "^${key}=" "$file"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+  else
+    echo "${key}=${value}" >> "$file"
+  fi
+}
+
+# read_env <file> <key>
+read_env() {
+  grep "^${2}=" "$1" | cut -d'=' -f2-
+}
 
 # Read terraform outputs
 echo "Reading terraform outputs from $TF_DIR ..."
 cd "$TF_DIR"
 
-update_env() {
-  local key="$1"
-  local value="$2"
-  if grep -q "^${key}=" "$ENV_FILE"; then
-    sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+case "$CLOUD" in
+  azure)
+    update_env "$CLOUD_ENV_FILE" "RESOURCE_GROUP_NAME"   "$(terraform output -raw resource_group_name)"
+    update_env "$CLOUD_ENV_FILE" "KEY_VAULT_NAME"        "$(terraform output -raw key_vault_name)"
+    update_env "$CLOUD_ENV_FILE" "FUNCTION_APP_URL"      "$(terraform output -raw function_app_url)"
+    update_env "$CLOUD_ENV_FILE" "FUNCTION_APP_NAME"     "$(terraform output -raw function_app_name)"
+    update_env "$CLOUD_ENV_FILE" "BATCH_ACCOUNT_NAME"    "$(terraform output -raw batch_account_name)"
+    update_env "$CLOUD_ENV_FILE" "IMAGE_GALLERY_NAME"    "$(terraform output -raw image_gallery_name)"
+    update_env "$CLOUD_ENV_FILE" "IMAGE_DEFINITION_NAME" "$(terraform output -raw image_definition_name)"
+    ;;
+  gcp)
+    update_env "$CLOUD_ENV_FILE" "ARTIFACT_BUCKET_NAME" "$(terraform output -raw artifact_bucket_name)"
+    update_env "$CLOUD_ENV_FILE" "SECRET_STORE_NAME"    "$(terraform output -raw unity_license_secret_id)"
+    ;;
+  *)
+    echo "Unknown cloud: $CLOUD (expected azure or gcp)" >&2
+    exit 1
+    ;;
+esac
+
+echo "$(basename "$CLOUD_ENV_FILE") updated with terraform outputs."
+
+# --- Generate terraform.tfvars for the ephemeral config ---
+
+ADMIN_PASSWORD="$(read_env "$ENV_FILE" ADMIN_PASSWORD)"
+REPO_URL="$(read_env "$ENV_FILE" REPO_URL)"
+PLATFORM="$(read_env "$ENV_FILE" PLATFORM)"
+
+if [ "$CLOUD" = "azure" ]; then
+  TFVARS_FILE="$REPO_ROOT/terraform/azure/ephemeral/terraform.tfvars"
+
+  # GITHUB_TOKEN is Azure-only (legacy webhook registration flow)
+  GITHUB_TOKEN="$(read_env "$CLOUD_ENV_FILE" GITHUB_TOKEN)"
+  FUNCTION_APP_URL="$(read_env "$CLOUD_ENV_FILE" FUNCTION_APP_URL)"
+  KEY_VAULT_NAME="$(read_env "$CLOUD_ENV_FILE" KEY_VAULT_NAME)"
+  RESOURCE_GROUP_NAME="$(read_env "$CLOUD_ENV_FILE" RESOURCE_GROUP_NAME)"
+  IMAGE_GALLERY_NAME="$(read_env "$CLOUD_ENV_FILE" IMAGE_GALLERY_NAME)"
+  IMAGE_DEFINITION_NAME="$(read_env "$CLOUD_ENV_FILE" IMAGE_DEFINITION_NAME)"
+
+  if [ -z "$ADMIN_PASSWORD" ] || [ -z "$REPO_URL" ] || [ -z "$FUNCTION_APP_URL" ] || [ -z "$PLATFORM" ]; then
+    echo "Warning: ADMIN_PASSWORD, REPO_URL, FUNCTION_APP_URL, or PLATFORM is empty"
+    echo "Skipping terraform.tfvars generation. Fill in .env / .env.azure and run again."
   else
-    echo "${key}=${value}" >> "$ENV_FILE"
-  fi
-}
-
-update_env "RESOURCE_GROUP_NAME" "$(terraform output -raw resource_group_name)"
-update_env "KEY_VAULT_NAME"      "$(terraform output -raw key_vault_name)"
-update_env "FUNCTION_APP_URL"    "$(terraform output -raw function_app_url)"
-update_env "FUNCTION_APP_NAME"   "$(terraform output -raw function_app_name)"
-update_env "BATCH_ACCOUNT_NAME"  "$(terraform output -raw batch_account_name)"
-update_env "IMAGE_GALLERY_NAME"  "$(terraform output -raw image_gallery_name)"
-update_env "IMAGE_DEFINITION_NAME" "$(terraform output -raw image_definition_name)"
-
-echo ".env updated with terraform outputs."
-
-# --- Generate terraform.tfvars for ephemeral ---
-TFVARS_FILE="$REPO_ROOT/terraform/azure/ephemeral/terraform.tfvars"
-
-read_env() {
-  grep "^${1}=" "$ENV_FILE" | cut -d'=' -f2-
-}
-
-ADMIN_PASSWORD="$(read_env ADMIN_PASSWORD)"
-REPO_URL="$(read_env REPO_URL)"
-FUNCTION_APP_URL="$(read_env FUNCTION_APP_URL)"
-PLATFORM="$(read_env PLATFORM)"
-KEY_VAULT_NAME="$(read_env KEY_VAULT_NAME)"
-RESOURCE_GROUP_NAME="$(read_env RESOURCE_GROUP_NAME)"
-IMAGE_GALLERY_NAME="$(read_env IMAGE_GALLERY_NAME)"
-IMAGE_DEFINITION_NAME="$(read_env IMAGE_DEFINITION_NAME)"
-GITHUB_TOKEN="$(read_env GITHUB_TOKEN)"
-
-if [ -z "$ADMIN_PASSWORD" ] || [ -z "$REPO_URL" ] || [ -z "$FUNCTION_APP_URL" ] || [ -z "$PLATFORM" ]; then
-  echo "Warning: ADMIN_PASSWORD, REPO_URL, FUNCTION_APP_URL, or PLATFORM is empty in .env"
-  echo "Skipping terraform.tfvars generation. Fill in .env and run again."
-else
-  cat > "$TFVARS_FILE" << EOF
+    cat > "$TFVARS_FILE" << EOF
 admin_password        = "$ADMIN_PASSWORD"
 repo_url              = "$REPO_URL"
 function_app_url      = "$FUNCTION_APP_URL"
@@ -70,7 +102,11 @@ image_gallery_name    = "$IMAGE_GALLERY_NAME"
 image_definition_name = "$IMAGE_DEFINITION_NAME"
 github_token          = "$GITHUB_TOKEN"
 EOF
-  echo "Generated $TFVARS_FILE"
+    echo "Generated $TFVARS_FILE"
+  fi
+else
+  # GCP ephemeral tfvars generation is added with terraform/gcp/ephemeral (Issue C)
+  echo "GCP ephemeral tfvars generation: not yet implemented (Issue C)."
 fi
 
 echo "Done."

--- a/terraform/gcp/persistent/.terraform.lock.hcl
+++ b/terraform/gcp/persistent/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:DNt2+WSTnrNlWVUml87IQb+f/aICd3TKETxWIJAELyA=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/terraform/gcp/persistent/main.tf
+++ b/terraform/gcp/persistent/main.tf
@@ -1,0 +1,92 @@
+# =========================
+# -- Terraform Configuration
+# =========================
+# GCP counterpart of terraform/azure/persistent.
+# Scoped to the license bootstrap cycle (serverless CI design, Discord-triggered):
+# no GitHub-webhook resources, no function resources yet.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# Uses Application Default Credentials (`gcloud auth application-default login`).
+# No project set at provider level — the project itself is created below.
+provider "google" {}
+
+# =========================
+# -- Project
+# =========================
+# GCP has no Resource Group; the project is the container for everything.
+# Created under the jindokim-kor-org organization (not "No organization")
+# and linked to the billing account so resources can be provisioned.
+# deletion_policy = "DELETE": `terraform destroy` shuts the project down
+# (default "PREVENT" would refuse).
+
+resource "google_project" "main" {
+  name            = "Unity CI GCP"
+  project_id      = var.project_id
+  org_id          = var.org_id
+  billing_account = var.billing_account
+  deletion_policy = "DELETE"
+}
+
+# =========================
+# -- APIs
+# =========================
+# GCP requires each service API to be enabled per-project before use
+# (Azure has no equivalent step — services are always callable).
+# disable_on_destroy = false: destroying this resource just abandons the
+# enablement instead of force-disabling the API, which can wedge teardown.
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "compute.googleapis.com",       # bootstrap VM (ephemeral) + Batch node VMs
+    "batch.googleapis.com",         # build execution (Azure Batch equivalent)
+    "secretmanager.googleapis.com", # license storage (Key Vault equivalent)
+    "storage.googleapis.com",       # artifact bucket (Blob Storage equivalent)
+  ])
+  project            = google_project.main.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# =========================
+# -- Artifact Bucket
+# =========================
+# Build artifacts (Unity build output) land here.
+# Bucket names are globally unique, so the project id is used as prefix.
+# force_destroy = true: allow `terraform destroy` even when builds exist.
+
+resource "google_storage_bucket" "artifacts" {
+  project                     = google_project.main.project_id
+  name                        = "${var.project_id}-artifacts"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = true
+
+  depends_on = [google_project_service.apis]
+}
+
+# =========================
+# -- Unity License Secret
+# =========================
+# Container only — the actual license version (.ulf content) is added by
+# downloader-gcp running on the bootstrap VM, mirroring how the Azure
+# downloader uploads UNITY-LICENSE to Key Vault.
+# No webhook secret here: GitHub connects only to Discord in this design.
+
+resource "google_secret_manager_secret" "unity_license" {
+  project   = google_project.main.project_id
+  secret_id = "unity-license"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/terraform/gcp/persistent/outputs.tf
+++ b/terraform/gcp/persistent/outputs.tf
@@ -1,0 +1,24 @@
+# =========================
+# -- Outputs
+# =========================
+# Cross-cloud contract: same *meanings* as terraform/azure/persistent outputs,
+# consumed later by sync-env / ephemeral tfvars generation.
+#   Azure key_vault_name  ↔ GCP secret_store (secret id)
+#   Azure storage account ↔ GCP artifact_bucket_name
+#   Azure resource group  ↔ GCP project_id (the container concept)
+
+output "project_id" {
+  value = google_project.main.project_id
+}
+
+output "region" {
+  value = var.region
+}
+
+output "artifact_bucket_name" {
+  value = google_storage_bucket.artifacts.name
+}
+
+output "unity_license_secret_id" {
+  value = google_secret_manager_secret.unity_license.secret_id
+}

--- a/terraform/gcp/persistent/variables.tf
+++ b/terraform/gcp/persistent/variables.tf
@@ -1,0 +1,27 @@
+# =========================
+# -- Variables
+# =========================
+# Per-user values (org, billing, project id) have NO defaults on purpose —
+# they are personal identifiers, supplied via terraform.tfvars (gitignored),
+# which is generated from .env (see .env.example, GCP section).
+
+variable "org_id" {
+  description = "GCP organization ID this project is created under"
+  type        = string
+}
+
+variable "billing_account" {
+  description = "Billing account ID the project is linked to"
+  type        = string
+}
+
+variable "project_id" {
+  description = "Globally-unique GCP project ID (also prefixes the artifact bucket name)"
+  type        = string
+}
+
+variable "region" {
+  description = "Default region for regional resources (artifact bucket)"
+  type        = string
+  default     = "northamerica-northeast2" # Toronto (GCP's canada-central equivalent)
+}


### PR DESCRIPTION
Closes #45

## What

GCP persistent layer + per-cloud environment file structure. Scoped to the serverless CI design (Discord-triggered): no GitHub-webhook resources, no function resources.

## Changes

**terraform/gcp/persistent** (new)
- Project under the organization, billing-linked (`deletion_policy = "DELETE"`)
- APIs: compute, batch, secretmanager, storage (`disable_on_destroy = false`)
- Artifact bucket in `northamerica-northeast2` (Toronto)
- `unity-license` Secret Manager container — version added later by downloader-gcp
- Per-user IDs (org/billing/project) are required variables with **no defaults**; values live in gitignored `terraform.tfvars`

**Env file split**
- `.env` (common: REPO_URL, PLATFORM, ADMIN_PASSWORD) / `.env.azure` / `.env.gcp`, each with a tracked `.example`
- `.gitignore`: `.env*` ignored, `!.env*.example` kept
- `GITHUB_TOKEN` moved to `.env.azure` — only the legacy webhook flow uses it; the Discord design has no cloud↔GitHub link

**scripts/sync-env.sh**
- Now takes `[azure|gcp]`, reads the matching `terraform/<cloud>/persistent` outputs, writes the matching `.env.<cloud>`
- GCP ephemeral tfvars generation deferred to the ephemeral issue

## Verification

- `terraform apply`: 7 added, 0 changed, 0 destroyed — outputs: `unity-ci-gcp-0724`, `unity-ci-gcp-0724-artifacts`, `unity-license`
- `./scripts/sync-env.sh gcp` run live: outputs written into `.env.gcp`
- Idle cost after apply: $0 (no compute; empty bucket; secret container in free tier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
